### PR TITLE
Port docker build workflow from hoyolab-auto

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,0 +1,44 @@
+name: Build and Push Docker Image
+
+permissions:
+  contents: read
+  packages: write
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare Tags
+        run: |
+          echo "REPO_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
+        env:
+          GITHUB_REPOSITORY_OWNER: "${{ github.repository_owner }}"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/${{ env.REPO_OWNER }}/endfield-auto:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
 services:
-  endfield-auto:
-    build: .
+  instance:
+    image: ghcr.io/torikushiii/endfield-auto:latest
+    restart: on-failure:5
     container_name: endfield-auto
-    restart: always
+    network_mode: bridge
     volumes:
       - ./config.json:/app/config.json
     environment:


### PR DESCRIPTION
Ports the multi-arch Docker build workflow from `hoyolab-auto` with a few changes:

* Authentication: Switched from manual PATs (`GHCR_TOKEN`) to the automatic `GITHUB_TOKEN` with `packages: write` permissions.
* Tagging: Added a step to force the repository owner name to lowercase (`REPO_OWNER`).

*Note: If the `GITHUB_TOKEN` method causes issues, I can easily revert to the original PAT-based implementation.*